### PR TITLE
add argocd operator

### DIFF
--- a/k8s/base/argocd/kustomization.yaml
+++ b/k8s/base/argocd/kustomization.yaml
@@ -1,0 +1,5 @@
+namespace: argocd
+resources:
+  - namespace.yaml
+  - operatorgroup.yaml
+  - subscription.yaml

--- a/k8s/base/argocd/namespace.yaml
+++ b/k8s/base/argocd/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+spec: {}

--- a/k8s/base/argocd/operatorgroup.yaml
+++ b/k8s/base/argocd/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: argocd-group
+  namespace: argocd
+spec:
+  targetNamespaces:
+  - argocd

--- a/k8s/base/argocd/subscription.yaml
+++ b/k8s/base/argocd/subscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: argocd-operator
+  namespace: argocd
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: argocd-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: argocd-operator.v0.0.15

--- a/k8s/overlays/nerc-shift-1/argocd/argocd.yaml
+++ b/k8s/overlays/nerc-shift-1/argocd/argocd.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: nerc-argocd
+  namespace: argocd
+spec:
+  controller:
+    processors: {}
+  dex: {}
+  grafana:
+    enabled: false
+    ingress:
+      enabled: false
+    route:
+      enabled: false
+  ha:
+    enabled: false
+  initialSSHKnownHosts: {}
+  prometheus:
+    enabled: false
+    ingress:
+      enabled: false
+    route:
+      enabled: false
+  rbac: {}
+  redis: {}
+  repo: {}
+  server:
+    autoscale:
+      enabled: false
+    grpc:
+      ingress:
+        enabled: false
+    ingress:
+      enabled: true
+    route:
+      enabled: true
+    service:
+      type: ""
+  tls:
+    ca: {}

--- a/k8s/overlays/nerc-shift-1/argocd/clusterrolebindings/application-controller.yaml
+++ b/k8s/overlays/nerc-shift-1/argocd/clusterrolebindings/application-controller.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-admin-1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: nerc-argocd-argocd-application-controller
+  namespace: argocd

--- a/k8s/overlays/nerc-shift-1/argocd/clusterrolebindings/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/argocd/clusterrolebindings/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - server.yaml
+  - application-controller.yaml

--- a/k8s/overlays/nerc-shift-1/argocd/clusterrolebindings/server.yaml
+++ b/k8s/overlays/nerc-shift-1/argocd/clusterrolebindings/server.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-admin-0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: nerc-argocd-argocd-server
+  namespace: argocd

--- a/k8s/overlays/nerc-shift-1/argocd/configmap.yaml
+++ b/k8s/overlays/nerc-shift-1/argocd/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: nerc-argocd
+    app.kubernetes.io/name: argocd-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-cm
+  namespace: argocd
+data:
+  kustomize.buildOptions: --reorder none

--- a/k8s/overlays/nerc-shift-1/argocd/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/argocd/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - ../../../base/argocd
+  - configmap.yaml
+  - securitycontextconstraints.yaml
+  - argocd.yaml
+  - clusterrolebindings

--- a/k8s/overlays/nerc-shift-1/argocd/securitycontextconstraints.yaml
+++ b/k8s/overlays/nerc-shift-1/argocd/securitycontextconstraints.yaml
@@ -1,0 +1,16 @@
+kind: SecurityContextConstraints
+apiVersion: v1
+metadata:
+  name: argocd
+allowPrivilegedContainer: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:argocd:nerc-argocd-argocd-server
+  - system:serviceaccount:argocd:nerc-argocd-argocd-application-controller

--- a/k8s/overlays/nerc-shift-1/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - argocd
   - local-storage
   - ocs
   - stf


### PR DESCRIPTION
TODO:
- [ ] setup `initialRepositories` param to bootstrap `nerc-argocd-apps` repo. (see: https://argocd-operator.readthedocs.io/en/latest/reference/argocd/#initial-repositories)

Punting on that for now - need to figure out how to specify a path in the `initialRepositories` param.