### PR TITLE
local-storage and OCS operator fixes

### DIFF
--- a/k8s/overlays/nerc-shift-1/local-storage/localvolumediscovery.yaml
+++ b/k8s/overlays/nerc-shift-1/local-storage/localvolumediscovery.yaml
@@ -2,6 +2,7 @@ apiVersion: local.storage.openshift.io/v1alpha1
 kind: LocalVolumeDiscovery
 metadata:
   name: auto-discover-devices
+  namespace: openshift-local-storage
 spec:
   nodeSelector:
     nodeSelectorTerms:

--- a/k8s/overlays/nerc-shift-1/local-storage/localvolumeset.yaml
+++ b/k8s/overlays/nerc-shift-1/local-storage/localvolumeset.yaml
@@ -2,6 +2,7 @@ apiVersion: local.storage.openshift.io/v1alpha1
 kind: LocalVolumeSet
 metadata:
   name: local-sdb
+  namespace: openshift-local-storage
 spec:
   deviceInclusionSpec:
     deviceTypes:

--- a/k8s/overlays/nerc-shift-1/ocs/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/ocs/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
   - ../../../base/ocs
-  - storageclass.yaml
   - storagecluster.yaml
+  - storageclass.yaml

--- a/k8s/overlays/nerc-shift-1/ocs/storagecluster.yaml
+++ b/k8s/overlays/nerc-shift-1/ocs/storagecluster.yaml
@@ -2,6 +2,7 @@ apiVersion: ocs.openshift.io/v1
 kind: StorageCluster
 metadata:
   name: ocs-storagecluster
+  namespace: openshift-storage
 spec:
   storageDeviceSets:
     - config: {}


### PR DESCRIPTION
- Namespace fixes in both `local-storage` and `ocs` operators
- Include missing `local-sdb` storageclass.