### PR TITLE
add nmstate operator

### DIFF
--- a/k8s/base/nmstate/kustomization.yaml
+++ b/k8s/base/nmstate/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - namespace.yaml
+  - operatorgroup.yaml
+  - subscription.yaml
+  - nmstate.yaml

--- a/k8s/base/nmstate/namespace.yaml
+++ b/k8s/base/nmstate/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-nmstate
+spec: {}

--- a/k8s/base/nmstate/nmstate.yaml
+++ b/k8s/base/nmstate/nmstate.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+items:
+- apiVersion: nmstate.io/v1beta1
+  kind: NMState
+  metadata:
+    name: nmstate
+  spec:
+    nodeSelector:
+      kubernetes.io/arch: amd64
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/k8s/base/nmstate/operatorgroup.yaml
+++ b/k8s/base/nmstate/operatorgroup.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: NMState.v1beta1.nmstate.io
+  name: openshift-nmstate
+  namespace: openshift-nmstate
+spec:
+  targetNamespaces:
+  - openshift-nmstate

--- a/k8s/base/nmstate/subscription.yaml
+++ b/k8s/base/nmstate/subscription.yaml
@@ -1,0 +1,14 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/kubernetes-nmstate-operator.openshift-nmstate: ""
+  name: kubernetes-nmstate-operator
+  namespace: openshift-nmstate
+spec:
+  channel: "4.8"
+  installPlanApproval: Automatic
+  name: kubernetes-nmstate-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: kubernetes-nmstate-operator.4.8.0-202202152218


### PR DESCRIPTION
Relies on a singleton nmstate instance living in `openshift-nmstate` in
order to function properly The singleton NMState resource has to exist
before the APIs are available, it seems, which is why it's included in
base with a very broad node selector. The CRs can select which nodes to
apply to via their own node selectors.