### PR TITLE
settings to scale elasticsearch to hold more logs

### DIFF
--- a/k8s/overlays/nerc-shift-0/eck/elasticsearch.yaml
+++ b/k8s/overlays/nerc-shift-0/eck/elasticsearch.yaml
@@ -7,7 +7,7 @@ spec:
   version: 7.17.0
   nodeSets:
     - name: default
-      count: 2
+      count: 10
       config:
         node.store.allow_mmap: true
       volumeClaimTemplates:
@@ -18,4 +18,4 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 300Gi
+                storage: 500Gi

--- a/k8s/overlays/nerc-shift-0/eck/elasticsearch.yaml
+++ b/k8s/overlays/nerc-shift-0/eck/elasticsearch.yaml
@@ -7,9 +7,9 @@ spec:
   version: 7.17.0
   nodeSets:
     - name: default
-      count: 1
+      count: 2
       config:
-        node.store.allow_mmap: false
+        node.store.allow_mmap: true
       volumeClaimTemplates:
         - metadata:
             name: elasticsearch-data
@@ -18,4 +18,4 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 200Gi
+                storage: 300Gi


### PR DESCRIPTION
- changed node.store.allow_mmap to true based on recommendations in:
  https://www.elastic.co/guide/en/cloud-on-k8s/2.1/k8s-virtual-memory.html
- scaled elastic deployment from 1 node, to 2
- increased storage volume from 200GB to 300GB
