### PR TITLE
nerc-shift-0: add image registry with 100Gi PV

### DIFF
--- a/k8s/overlays/nerc-shift-0/image-registry/config.yaml
+++ b/k8s/overlays/nerc-shift-0/image-registry/config.yaml
@@ -1,0 +1,20 @@
+apiVersion: imageregistry.operator.openshift.io/v1
+kind: Config
+metadata:
+  name: cluster
+spec:
+  logLevel: Normal
+  managementState: Managed
+  observedConfig: null
+  operatorLogLevel: Normal
+  replicas: 3
+  requests:
+    read:
+      maxWaitInQueue: 0s
+    write:
+      maxWaitInQueue: 0s
+  rolloutStrategy: RollingUpdate
+  unsupportedConfigOverrides: null
+  storage:
+    pvc:
+      claim: image-registry-storage

--- a/k8s/overlays/nerc-shift-0/image-registry/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-0/image-registry/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pvc.yaml
+  - config.yaml

--- a/k8s/overlays/nerc-shift-0/image-registry/pvc.yaml
+++ b/k8s/overlays/nerc-shift-0/image-registry/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    imageregistry.openshift.io: "true"
+  name: image-registry-storage
+  namespace: openshift-image-registry
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Gi

--- a/k8s/overlays/nerc-shift-0/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-0/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - external-secrets
   - oauth-github.yaml
   - stf
+  - image-registry


### PR DESCRIPTION
https://docs.openshift.com/container-platform/4.8/registry/configuring-registry-operator.html#image-registry-on-bare-metal-vsphere