### PR TITLE
image-registry: use cephfs stoage class for pvc

### DIFF
--- a/k8s/overlays/nerc-shift-0/image-registry/pvc.yaml
+++ b/k8s/overlays/nerc-shift-0/image-registry/pvc.yaml
@@ -11,3 +11,4 @@ spec:
   resources:
     requests:
       storage: 100Gi
+  storageClassName: ocs-storagecluster-cephfs


### PR DESCRIPTION
Needed for `ReadWriteMany` mode