### PR TITLE
default ingress controller certs

### DIFF
--- a/k8s/base/ingress-controllers/default.yaml
+++ b/k8s/base/ingress-controllers/default.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  httpErrorCodePages:
+    name: ""
+  replicas: 2

--- a/k8s/base/ingress-controllers/kustomization.yaml
+++ b/k8s/base/ingress-controllers/kustomization.yaml
@@ -1,0 +1,3 @@
+---
+resources:
+  - default.yaml

--- a/k8s/overlays/nerc-shift-0/ingress-controllers/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-0/ingress-controllers/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+resources:
+  - ../../../base/ingress-controllers
+  - secrets/default-ingress-certificate.yaml
+
+patches:
+  - path: patches/default.yaml

--- a/k8s/overlays/nerc-shift-0/ingress-controllers/patches/default.yaml
+++ b/k8s/overlays/nerc-shift-0/ingress-controllers/patches/default.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  defaultCertificate:
+    name: default-ingress-certificate

--- a/k8s/overlays/nerc-shift-0/ingress-controllers/secrets/default-ingress-certificate.yaml
+++ b/k8s/overlays/nerc-shift-0/ingress-controllers/secrets/default-ingress-certificate.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: default-ingress-certificate
+  namespace: openshift-ingress
+spec:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: default-ingress-certificate
+    template:
+      type: kubernetes.io/tls
+  dataFrom:
+    - key: openshift-ingress/default-ingress-certificate

--- a/k8s/overlays/nerc-shift-0/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-0/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - stf
   - image-registry
   - kubelet
+  - ingress-controllers

--- a/k8s/overlays/nerc-shift-1/ingress-controllers/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/ingress-controllers/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+resources:
+  - ../../../base/ingress-controllers
+  - secrets/default-ingress-certificate.yaml
+
+patches:
+  - path: patches/default.yaml

--- a/k8s/overlays/nerc-shift-1/ingress-controllers/patches/default.yaml
+++ b/k8s/overlays/nerc-shift-1/ingress-controllers/patches/default.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  defaultCertificate:
+    name: default-ingress-certificate

--- a/k8s/overlays/nerc-shift-1/ingress-controllers/secrets/default-ingress-certificate.yaml
+++ b/k8s/overlays/nerc-shift-1/ingress-controllers/secrets/default-ingress-certificate.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: default-ingress-certificate
+  namespace: openshift-ingress
+spec:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: default-ingress-certificate
+    template:
+      type: kubernetes.io/tls
+  dataFrom:
+    - key: openshift-ingress/default-ingress-certificate

--- a/k8s/overlays/nerc-shift-1/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - keycloak
   - cert-manager
   - kubelet
+  - ingress-controllers


### PR DESCRIPTION
This sets a static wild card cert from InCommon for now to fix ssl issues when using routes that rely on the default ingress controller to provide SSL.