### PR TITLE
avoid unintended keycloak upgrades

### DIFF
--- a/k8s/base/keycloak/subscription.yaml
+++ b/k8s/base/keycloak/subscription.yaml
@@ -7,3 +7,4 @@ spec:
   name: keycloak-operator
   source: operatorhubio-operators
   sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual


### PR DESCRIPTION
Recently the keycloak operator upgraded automatically which upgraded our keycloak deployment to the latest 19.x version and broke regapp. This sets the install plan to `manual` for the keycloak operator to avoid keycloak being updated before we're ready.