### PR TITLE
openshift-monitoring persistent storage updates for nerc-shift-{0,1}

### DIFF
--- a/k8s/overlays/nerc-shift-0/openshift-monitoring/configmaps/cluster-monitoring-config.yaml
+++ b/k8s/overlays/nerc-shift-0/openshift-monitoring/configmaps/cluster-monitoring-config.yaml
@@ -6,12 +6,14 @@ metadata:
 data:
   config.yaml: |
     alertmanagerMain:
+      retention: 2w
       volumeClaimTemplate:
         spec:
           resources:
             requests:
               storage: 50Gi
     prometheusK8s:
+      retention: 2w
       volumeClaimTemplate:
         spec:
           resources:

--- a/k8s/overlays/nerc-shift-0/openshift-monitoring/configmaps/cluster-monitoring-config.yaml
+++ b/k8s/overlays/nerc-shift-0/openshift-monitoring/configmaps/cluster-monitoring-config.yaml
@@ -11,3 +11,9 @@ data:
           resources:
             requests:
               storage: 50Gi
+    prometheusK8s:
+      volumeClaimTemplate:
+        spec:
+          resources:
+            requests:
+              storage: 50Gi

--- a/k8s/overlays/nerc-shift-1/openshift-monitoring/configmaps/cluster-monitoring-config.yaml
+++ b/k8s/overlays/nerc-shift-1/openshift-monitoring/configmaps/cluster-monitoring-config.yaml
@@ -6,12 +6,14 @@ metadata:
 data:
   config.yaml: |
     alertmanagerMain:
+      retention: 2w
       volumeClaimTemplate:
         spec:
           resources:
             requests:
               storage: 50Gi
     prometheusK8s:
+      retention: 2w
       volumeClaimTemplate:
         spec:
           resources:

--- a/k8s/overlays/nerc-shift-1/openshift-monitoring/configmaps/cluster-monitoring-config.yaml
+++ b/k8s/overlays/nerc-shift-1/openshift-monitoring/configmaps/cluster-monitoring-config.yaml
@@ -11,3 +11,9 @@ data:
           resources:
             requests:
               storage: 50Gi
+    prometheusK8s:
+      volumeClaimTemplate:
+        spec:
+          resources:
+            requests:
+              storage: 50Gi


### PR DESCRIPTION
This adds persistent storage for the openshift-monitoring prometheus instances and sets the retention for both alert-manager and prometheus monitoring data to 2 weeks.

https://docs.openshift.com/container-platform/4.8/monitoring/configuring-the-monitoring-stack.html#configuring-persistent-storage