### PR TITLE
add valid cert for the API servers

### DIFF
--- a/k8s/base/api-server/default.yaml
+++ b/k8s/base/api-server/default.yaml
@@ -1,0 +1,13 @@
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    oauth-apiserver.openshift.io/secure-token-storage: "true"
+    release.openshift.io/create-only: "true"
+  name: cluster
+spec:
+  audit:
+    profile: Default

--- a/k8s/base/api-server/kustomization.yaml
+++ b/k8s/base/api-server/kustomization.yaml
@@ -1,0 +1,3 @@
+---
+resources:
+  - default.yaml

--- a/k8s/overlays/nerc-shift-0/api-server/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-0/api-server/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+resources:
+  - ../../../base/api-server
+  - secrets/default-api-server-certificate.yaml
+
+patches:
+  - path: patches/default.yaml

--- a/k8s/overlays/nerc-shift-0/api-server/patches/default.yaml
+++ b/k8s/overlays/nerc-shift-0/api-server/patches/default.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+spec:
+  servingCerts:
+    namedCertificates:
+      - names:
+        - api.nerc-shift-0.rc.fas.harvard.edu
+        servingCertificate:
+          name: default-api-server-certificate

--- a/k8s/overlays/nerc-shift-0/api-server/secrets/default-api-server-certificate.yaml
+++ b/k8s/overlays/nerc-shift-0/api-server/secrets/default-api-server-certificate.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: default-api-server-certificate
+  namespace: openshift-config
+spec:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: default-api-server-certificate
+    template:
+      type: kubernetes.io/tls
+  dataFrom:
+    - key: openshift-api-server/default-api-server-certificate

--- a/k8s/overlays/nerc-shift-0/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-0/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - image-registry
   - kubelet
   - ingress-controllers
+  - api-server

--- a/k8s/overlays/nerc-shift-1/api-server/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/api-server/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+resources:
+  - ../../../base/api-server
+  - secrets/default-api-server-certificate.yaml
+
+patches:
+  - path: patches/default.yaml

--- a/k8s/overlays/nerc-shift-1/api-server/patches/default.yaml
+++ b/k8s/overlays/nerc-shift-1/api-server/patches/default.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+spec:
+  servingCerts:
+    namedCertificates:
+      - names:
+        - api.nerc-shift-1.rc.fas.harvard.edu
+        servingCertificate:
+          name: default-api-server-certificate

--- a/k8s/overlays/nerc-shift-1/api-server/secrets/default-api-server-certificate.yaml
+++ b/k8s/overlays/nerc-shift-1/api-server/secrets/default-api-server-certificate.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: default-api-server-certificate
+  namespace: openshift-config
+spec:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: default-api-server-certificate
+    template:
+      type: kubernetes.io/tls
+  dataFrom:
+    - key: openshift-api-server/default-api-server-certificate

--- a/k8s/overlays/nerc-shift-1/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - cert-manager
   - kubelet
   - ingress-controllers
+  - api-server


### PR DESCRIPTION
This configures the APIServer on `nerc-shift-0` and `nerc-shift-1` clusters to use a valid SSL cert.