### PR TITLE
nerc-shift-1: add postgres 13.x imagestreams

### DIFF
--- a/k8s/overlays/nerc-shift-1/postgres/imagestreams/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/postgres/imagestreams/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - postgres.yaml
+  - pgbouncer.yaml
+  - pgbackrest.yaml

--- a/k8s/overlays/nerc-shift-1/postgres/imagestreams/pgbackrest.yaml
+++ b/k8s/overlays/nerc-shift-1/postgres/imagestreams/pgbackrest.yaml
@@ -1,0 +1,18 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: crunchy-pgbackrest
+  namespace: postgres-operator
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: latest
+      annotations: null
+      from:
+        kind: DockerImage
+        name: 'registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.41-2'
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Source

--- a/k8s/overlays/nerc-shift-1/postgres/imagestreams/pgbouncer.yaml
+++ b/k8s/overlays/nerc-shift-1/postgres/imagestreams/pgbouncer.yaml
@@ -1,0 +1,18 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: crunchy-pgbouncer
+  namespace: postgres-operator
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: latest
+      annotations: null
+      from:
+        kind: DockerImage
+        name: 'registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.17-5'
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Source

--- a/k8s/overlays/nerc-shift-1/postgres/imagestreams/postgres.yaml
+++ b/k8s/overlays/nerc-shift-1/postgres/imagestreams/postgres.yaml
@@ -1,0 +1,18 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: crunchy-postgres
+  namespace: postgres-operator
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: latest
+      annotations: null
+      from:
+        kind: DockerImage
+        name: 'registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-13.9-2'
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Source

--- a/k8s/overlays/nerc-shift-1/postgres/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/postgres/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
   - ../../../base/postgres
+  - imagestreams


### PR DESCRIPTION
Add imagestreams for the postgres 13.x images in use on nerc-shift-1 by keycloak, regapp, and coldfront. This is mostly for a backup but can also be used by the individual DB deployments in order to not rely on upstream availability of those images.