### PR TITLE
nerc-shift-1: configure image registry with PVC

### DIFF
--- a/k8s/base/image-registry/config.yaml
+++ b/k8s/base/image-registry/config.yaml
@@ -1,0 +1,18 @@
+apiVersion: imageregistry.operator.openshift.io/v1
+kind: Config
+metadata:
+  name: cluster
+spec:
+  logLevel: Normal
+  managementState: Managed
+  operatorLogLevel: Normal
+  replicas: 1
+  requests:
+    read:
+      maxWaitInQueue: 0s
+    write:
+      maxWaitInQueue: 0s
+  rolloutStrategy: Recreate
+  storage:
+    pvc:
+      claim: image-registry-storage

--- a/k8s/base/image-registry/kustomization.yaml
+++ b/k8s/base/image-registry/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - persistentvolumeclaim.yaml
+  - config.yaml

--- a/k8s/base/image-registry/persistentvolumeclaim.yaml
+++ b/k8s/base/image-registry/persistentvolumeclaim.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: image-registry-storage
+  namespace: openshift-image-registry
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi

--- a/k8s/overlays/nerc-shift-1/image-registry/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/image-registry/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../../../base/image-registry

--- a/k8s/overlays/nerc-shift-1/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - kubelet
   - ingress-controllers
   - api-server
+  - image-registry


### PR DESCRIPTION
This adds manifests to configure PVC storage for the local cluster image registry.

Added these manifests the `nerc-shift-1` cluster/overlay