### PR TITLE
use bank-vaults 1.18.0 image

### DIFF
--- a/k8s/overlays/nerc-shift-0/vault/cr.yaml
+++ b/k8s/overlays/nerc-shift-0/vault/cr.yaml
@@ -7,7 +7,7 @@ spec:
   size: 1
   image: vault:1.6.2
   # specify a custom bank-vaults image with bankVaultsImage:
-  # bankVaultsImage: ghcr.io/banzaicloud/bank-vaults:latest
+  bankVaultsImage: ghcr.io/banzaicloud/bank-vaults:1.18.0
 
   # Common annotations for all created resources
   annotations:

--- a/k8s/overlays/nerc-shift-1/vault/cr.yaml
+++ b/k8s/overlays/nerc-shift-1/vault/cr.yaml
@@ -7,7 +7,7 @@ spec:
   size: 1
   image: vault:1.6.2
   # specify a custom bank-vaults image with bankVaultsImage:
-  # bankVaultsImage: ghcr.io/banzaicloud/bank-vaults:latest
+  bankVaultsImage: ghcr.io/banzaicloud/bank-vaults:1.18.0
 
   # Common annotations for all created resources
   annotations:


### PR DESCRIPTION
The "latest" image uses a now deprecated version of the go-autorest package which causes the vault-configurer deployment to go into a crashloopbackoff state. Using the 1.18.0 bank vaults image gets around this issue.

See: https://github.com/bank-vaults/bank-vaults/pull/1903