### PR TITLE
enable pulling images from postgres-operator namespace

### DIFF
--- a/k8s/overlays/nerc-shift-1/postgres/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/postgres/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
   - ../../../base/postgres
   - imagestreams
+  - rolebindings

--- a/k8s/overlays/nerc-shift-1/postgres/rolebindings/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/postgres/rolebindings/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - postgres-operator-image-puller.yaml

--- a/k8s/overlays/nerc-shift-1/postgres/rolebindings/postgres-operator-image-puller.yaml
+++ b/k8s/overlays/nerc-shift-1/postgres/rolebindings/postgres-operator-image-puller.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:image-puller
+  namespace: postgres-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:image-puller
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:keycloak
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:regapp
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:coldfront
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:coldfront-staging


### PR DESCRIPTION
Currently this is limited to the following front-of-house namespaces:

- keycloak
- regapp
- coldfront
- coldfront-staging

This is needed in order to reference local registry versions of the crunchydata images created by https://github.com/nerc-project/nerc-k8s-operators/pull/45 from other namespaces (e.g. keycloak, regapp, coldfront, etc)